### PR TITLE
Avoid deprecated constructor naming

### DIFF
--- a/authentication.php
+++ b/authentication.php
@@ -29,7 +29,7 @@ class SimpleRealm {
      *    @param SimpleUrl $url    Somewhere in realm.
      *    @access public
      */
-    function SimpleRealm($type, $url) {
+    function __construct($type, $url) {
         $this->type = $type;
         $this->root = $url->getBasePath();
         $this->username = false;
@@ -135,7 +135,7 @@ class SimpleAuthenticator {
      *    Clears the realms.
      *    @access public
      */
-    function SimpleAuthenticator() {
+    function __construct() {
         $this->restartSession();
     }
 

--- a/eclipse.php
+++ b/eclipse.php
@@ -29,7 +29,7 @@ class EclipseReporter extends SimpleScorer {
      */
     function __construct(&$listener, $cc=false){
         $this->listener = &$listener;
-        $this->SimpleScorer();
+        parent::__construct();
         $this->case = "";
         $this->group = "";
         $this->method = "";
@@ -275,7 +275,7 @@ class EclipseReporter extends SimpleScorer {
 class EclipseInvoker extends SimpleInvokerDecorator{
     function __construct(&$invoker, &$listener) {
         $this->listener = &$listener;
-        $this->SimpleInvokerDecorator($invoker);
+        parent::__construct($invoker);
     }
 
     /**

--- a/extensions/coverage/test/test.php
+++ b/extensions/coverage/test/test.php
@@ -3,8 +3,8 @@
 require_once(dirname(__FILE__) . '/../../../autorun.php');
 
 class CoverageUnitTests extends TestSuite {
-    function CoverageUnitTests() {
-        $this->TestSuite('Coverage Unit tests');
+    function __construct() {
+        parent::__construct('Coverage Unit tests');
         $path = dirname(__FILE__) . '/*_test.php';
         foreach(glob($path) as $test) {
             $this->addFile($test);

--- a/extensions/dom_tester/test/dom_tester_test.php
+++ b/extensions/dom_tester/test/dom_tester_test.php
@@ -21,7 +21,7 @@ class TestOfLiveCssSelectors extends DomTestCase {
 
 class TestOfCssSelectors extends UnitTestCase {
 
-	function TestOfCssSelectors() {
+	function __construct() {
 		$html = file_get_contents(dirname(__FILE__) . '/support/dom_tester.html');
 		$this->dom = new DomDocument('1.0', 'utf-8');
 		$this->dom->validateOnParse = true;
@@ -182,7 +182,7 @@ class TestOfCssSelectors extends UnitTestCase {
 }
 
 class TestsOfChildAndAdjacentSelectors extends DomTestCase {
-	function TestsOfChildAndAdjacentSelectors() {
+	function __construct() {
 		$html = file_get_contents(dirname(__FILE__) . '/support/child_adjacent.html');
 		$this->dom = new DomDocument('1.0', 'utf-8');
 		$this->dom->validateOnParse = true;

--- a/extensions/treemap_reporter/treemap_recorder.php
+++ b/extensions/treemap_reporter/treemap_recorder.php
@@ -23,8 +23,8 @@ class TreemapRecorder extends SimpleReporter {
 	var $_stack;
 	var $_title;
 
-	function TreemapRecorder() {
-		$this->SimpleReporter();
+	function __construct() {
+		parent::__construct();
 		$this->_stack = new TreemapStack();
 		$this->_graph = null;
 	}

--- a/reflection_php4.php
+++ b/reflection_php4.php
@@ -20,7 +20,7 @@ class SimpleReflection {
      *    @param string $interface    Class or interface
      *                                to inspect.
      */
-    function SimpleReflection($interface) {
+    function __construct($interface) {
         $this->_interface = $interface;
     }
 

--- a/test/all_tests.php
+++ b/test/all_tests.php
@@ -2,8 +2,8 @@
 require_once(dirname(__FILE__) . '/../autorun.php');
 
 class AllTests extends TestSuite {
-    function AllTests() {
-        $this->TestSuite('All tests for SimpleTest ' . SimpleTest::getVersion());
+    function __construct() {
+        parent::__construct('All tests for SimpleTest ' . SimpleTest::getVersion());
         $this->addFile(dirname(__FILE__) . '/unit_tests.php');
         $this->addFile(dirname(__FILE__) . '/shell_test.php');
         $this->addFile(dirname(__FILE__) . '/live_test.php');

--- a/test/bad_test_suite.php
+++ b/test/bad_test_suite.php
@@ -2,8 +2,8 @@
 require_once(dirname(__FILE__) . '/../autorun.php');
 
 class BadTestCases extends TestSuite {
-    function BadTestCases() {
-        $this->TestSuite('Two bad test cases');
+    function __construct() {
+        parent::__construct('Two bad test cases');
         $this->addFile(dirname(__FILE__) . '/support/empty_test_file.php');
     }
 }

--- a/test/expectation_test.php
+++ b/test/expectation_test.php
@@ -80,7 +80,7 @@ class TestOfInequality extends UnitTestCase {
 class RecursiveNasty {
     private $me;
 
-    function RecursiveNasty() {
+    function __construct() {
         $this->me = $this;
     }
 }

--- a/test/extensions_tests.php
+++ b/test/extensions_tests.php
@@ -9,8 +9,8 @@ class ExtensionsTests extends TestSuite {
                       'Many extensions only work with PHP5 and above');
 	}
 
-    function ExtensionsTests() {
-        $this->TestSuite('Extension tests for SimpleTest ' . SimpleTest::getVersion());
+    function __construct() {
+        parent::__construct('Extension tests for SimpleTest ' . SimpleTest::getVersion());
 
 		$nodes = new RecursiveDirectoryIterator(dirname(__FILE__).'/../extensions/');
 		foreach(new RecursiveIteratorIterator($nodes) as $node) {

--- a/test/frames_test.php
+++ b/test/frames_test.php
@@ -16,7 +16,7 @@ class TestOfFrameset extends UnitTestCase {
         $this->assertEqual($frameset->getTitle(), 'This page');
     }
 
-    function TestHeadersReadFromFramesetByDefault() {
+    function testHeadersReadFromFramesetByDefault() {
         $page = new MockSimplePage();
         $page->setReturnValue('getHeaders', 'Header: content');
         $page->setReturnValue('getMimeType', 'text/xml');

--- a/test/mock_objects_test.php
+++ b/test/mock_objects_test.php
@@ -196,7 +196,7 @@ class TestOfCallSchedule extends UnitTestCase {
 }
 
 class Dummy {
-    function Dummy() {
+    function __construct() {
     }
 
     function aMethod() {
@@ -839,7 +839,7 @@ class TestOfPartialMocks extends UnitTestCase {
 }
 
 class ConstructorSuperClass {
-    function ConstructorSuperClass() { }
+    function __construct() { }
 }
 
 class ConstructorSubClass extends ConstructorSuperClass { }

--- a/test/site/page_request.php
+++ b/test/site/page_request.php
@@ -4,7 +4,7 @@
 class PageRequest {
     private $parsed;
     
-    function PageRequest($raw) {
+    function __construct($raw) {
         $statements = explode('&', $raw);
         $this->parsed = array();
         foreach ($statements as $statement) {

--- a/test/unit_tests.php
+++ b/test/unit_tests.php
@@ -8,8 +8,8 @@ require_once(dirname(__FILE__) . '/../web_tester.php');
 require_once(dirname(__FILE__) . '/../extensions/pear_test_case.php');
 
 class UnitTests extends TestSuite {
-    function UnitTests() {
-        $this->TestSuite('Unit tests');
+    function __construct() {
+        parent::__construct('Unit tests');
         $path = dirname(__FILE__);
         $this->addFile($path . '/errors_test.php');
         $this->addFile($path . '/exceptions_test.php');

--- a/test/visual_test.php
+++ b/test/visual_test.php
@@ -20,7 +20,7 @@ require_once('../xml.php');
 class TestDisplayClass {
     private $a;
 
-    function TestDisplayClass($a) {
+    function __construct($a) {
         $this->a = $a;
     }
 }
@@ -261,7 +261,7 @@ class FailingUnitTestCaseOutput extends UnitTestCase {
 }
 
 class Dummy {
-    function Dummy() {
+    function __construct() {
     }
 
     function a() {

--- a/test_case.php
+++ b/test_case.php
@@ -484,7 +484,7 @@ class TestSuite {
      *                            of the test.
      *    @access public
      */
-    function TestSuite($label = false) {
+    function __construct($label = false) {
         $this->label = $label;
         $this->test_cases = array();
     }
@@ -619,7 +619,7 @@ class BadTestSuite {
      *                            of the test.
      *    @access public
      */
-    function BadTestSuite($label, $error) {
+    function __construct($label, $error) {
         $this->label = $label;
         $this->error = $error;
     }

--- a/xml.php
+++ b/xml.php
@@ -299,7 +299,7 @@ class NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingXmlTag($attributes) {
+    function __construct($attributes) {
         $this->name = false;
         $this->attributes = $attributes;
     }
@@ -347,8 +347,8 @@ class NestingMethodTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingMethodTag($attributes) {
-        $this->NestingXmlTag($attributes);
+    function __construct($attributes) {
+        parent::__construct($attributes);
     }
 
     /**
@@ -387,8 +387,8 @@ class NestingCaseTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingCaseTag($attributes) {
-        $this->NestingXmlTag($attributes);
+    function __construct($attributes) {
+        parent::__construct($attributes);
     }
 
     /**
@@ -427,8 +427,8 @@ class NestingGroupTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingGroupTag($attributes) {
-        $this->NestingXmlTag($attributes);
+    function __construct($attributes) {
+        parent::__construct($attributes);
     }
 
     /**
@@ -485,7 +485,7 @@ class SimpleTestXmlParser {
      *    @param SimpleReporter $listener   Listener of tag events.
      *    @access public
      */
-    function SimpleTestXmlParser(&$listener) {
+    function __construct(&$listener) {
         $this->listener = &$listener;
         $this->expat = &$this->createParser();
         $this->tag_stack = array();


### PR DESCRIPTION
Currently the simpletest codebase is using a mixture of old and new style constructor naming. This patch ensures that new style constructors are consistently used, avoiding warnings with PHP 7.

Note that
 * old style constructors are still used in examples throughout the documentation, and
 * `createClassCode` in `MockGenerator` is still emitting old style constructors.

